### PR TITLE
Add CODEOWNERS file and CI pipeline configuration for automated builds

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# These owners will be default owners for everything
+* @Ross-T
+
+# Backend code ownership
+/backend/ @Ross-T
+
+# Frontend code ownership  
+/frontend/ @Ross-T

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI Pipeline
+
+on:
+  push:
+    branches: [ main, develop, feature/**, fix/** ]
+  pull_request:
+    branches: [ main, develop ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    
+    - name: Set up JDK 17
+      uses: actions/setup-java@v3
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        cache: maven
+    
+    - name: Build with Maven (verify compilation only)
+      run: mvn -B compile --file backend/pom.xml
+    
+    - name: Verify Test Compilation
+      run: mvn -B test-compile --file backend/pom.xml


### PR DESCRIPTION
This pull request introduces changes to the code ownership and continuous integration (CI) pipeline configuration. The key changes include setting up default code owners and configuring a CI pipeline to run on specific branches.

### Code Ownership:
* [`.github/CODEOWNERS`](diffhunk://#diff-3d36a1bf06148bc6ba1ce2ed3d19de32ea708d955fed212c0d27c536f0bd4da7R1-R8): Assigned `@Ross-T` as the default owner for all files, as well as specific ownership for the `/backend/` and `/frontend/` directories.

### CI Pipeline Configuration:
* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR1-R26): Added a new CI pipeline configuration that triggers on pushes to `main`, `develop`, `feature/**`, and `fix/**` branches, and on pull requests to `main` and `develop` branches. The pipeline includes steps for checking out the code, setting up JDK 17, compiling the Maven project, and verifying test compilation.